### PR TITLE
Update renovate grouping and manage golang updates

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -15,17 +15,25 @@
   "schedule": ["* * * * 1-5"],
   "packageRules": [
     {
-      "managers": ["asdf"],
-      "groupName": "asdf updates"
+      "matchManagers": ["asdf"],
+      "groupName": "asdf updates",
+      "matchDepNames": ["golang"],
+      "updateTypes": ["minor", "patch"]
     },
     {
-      "managers": ["github-actions"],
+      "matchManagers": ["github-actions"],
       "groupName": "GitHub Actions updates"
     },
     {
-      "managers": ["gomod"],
-      "groupName": "Go module updates"
-
+      "matchManagers": ["gomod"],
+      "groupName": "Go module updates",
+      "matchDepNames": ["go"],
+      "updateTypes": ["minor", "patch"]
+    },
+    {
+      "matchManagers": ["dockerfile"],
+      "matchDepNames": ["docker.io/library/golang"],
+      "updateTypes": ["minor", "patch"]
     }
   ]
 }


### PR DESCRIPTION
The first is to fix the grouping. The old config
was using "managers" instead of "matchManagers".

The second is to update golang patch and minor
versions. Right now, we're disabling all updates.