### PR TITLE
Ignore versions with a build number appended

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -27,11 +27,13 @@
       "matchManagers": ["dockerfile"],
       "matchDepNames": ["docker.io/library/golang"],
       "updateTypes": ["patch"],
+      "ignoreVersions": [".*-.*"],
       "groupName": "Go Docker updates"
     },
     {
       "matchManagers": ["dockerfile"],
       "excludePackageNames": ["docker.io/library/golang"],
+      "ignoreVersions": [".*-.*"],
       "groupName": "Docker updates"
     }
   ]

--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -1,10 +1,18 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>konflux-ci/mintmaker//config/renovate/renovate.json",
-    "github>conforma/.github//config/renovate/renovate.json"
+    "config:recommended",
+    ":gitSignOff",
+    ":disableDependencyDashboard"
   ],
-  "baseBranches": ["main", "release-v0.5", "release-v0.6"],
+  "ignorePresets": [
+    ":dependencyDashboard"
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "timezone": "America/New_York",
+  "schedule": ["* * * * 1-5"],
   "packageRules": [
     {
       "matchManagers": ["gomod"],


### PR DESCRIPTION
This will ignore any image update with a `-` in the tag, since we're getting updates from registry.access.redhat like so

```
registry.access.redhat.com/ubi9/ubi-minimal:9.5-1742914212@sha256:ac61c96b93894b9169221e87718733354dd3765dd4a62b275893c7ff0d876869
```