### PR TITLE
Enable renovate auto-merge PRs for GitHub Actions

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -46,6 +46,14 @@
       "excludePackageNames": ["docker.io/library/golang"],
       "versioning": "semver",
       "groupName": "Docker updates"
+    },
+    {
+      "matchFiles": [
+        ".github/workflows/*.yml",
+        ".github/workflows/*.yaml"
+      ],
+      "automerge": true,
+      "groupName": "GitHub Actions updates"
     }
   ]
 }

--- a/config/renovate/renovate.json5
+++ b/config/renovate/renovate.json5
@@ -64,6 +64,15 @@
       "excludePackageNames": ["docker.io/library/golang"],
       "versioning": "semver",
       "groupName": "Docker updates"
+    },
+    // Allow all GitHub Actions updates based on filename pattern matching
+    {
+      "matchFiles": [
+        ".github/workflows/*.yml",
+        ".github/workflows/*.yaml"
+      ],
+      "automerge": true,
+      "groupName": "GitHub Actions updates"
     }
   ]
 }


### PR DESCRIPTION
This auto-merge logic is based on filename pattern matching, for better precision.

Ref: https://issues.redhat.com/browse/EC-698