### PR TITLE
Enable MintMaker auto-merge PRs for Konflux refs

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -14,6 +14,11 @@
   "timezone": "America/New_York",
   "packageRules": [
     {
+      "matchManagers": ["tekton"],
+      "matchUpdateTypes": ["patch", "pin", "digest"],
+      "automerge": true
+    },
+    {
       "matchManagers": ["gomod"],
       "matchDepNames": ["go", "toolchain"],
       "updateTypes": ["patch"],

--- a/config/renovate/renovate.json5
+++ b/config/renovate/renovate.json5
@@ -14,6 +14,16 @@
   },
   "timezone": "America/New_York",
   "packageRules": [
+    // This overrides the default MintMaker config for Konflux CI tekton modules
+    // that is defined here:
+    // https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json
+    //
+    // The override is meant to automerge the konflux refs that don't require a migration
+    {
+      "matchManagers": ["tekton"],
+      "matchUpdateTypes": ["patch", "pin", "digest"],
+      "automerge": true
+    },
     // Only allow patch updates for go and toolchain in the go.mod file.
     // This applies to all go.mod files in a repo.
     // This is treated different than the rest of the gomod deps, because


### PR DESCRIPTION
Override the default MintMaker config for tekton modules, enabling the automerge for the ref bumps that don't require a migration.

Ref: https://issues.redhat.com/browse/EC-698