### PR TITLE
Iterate org-level Renovate configuration

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -1,143 +1,48 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": "Conforma organization Renovate configuration",
   "extends": [
-    "config:recommended",
-    ":gitSignOff",
-    ":disableDependencyDashboard"
+    ":prHourlyLimit2",
+    ":prConcurrentLimit10",
+    ":automergeAllPatch",
+    ":ignoreUnstable"
   ],
-  "ignorePresets": [
-    ":dependencyDashboard"
+  "labels": [
+    "dependencies"
   ],
-  "vulnerabilityAlerts": {
-    "enabled": true
-  },
-  "timezone": "America/New_York",
   "packageRules": [
     {
-      "description": "Group major Go version updates with clear labeling",
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchDepNames": [
-        "go",
-        "toolchain"
-      ],
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "groupName": "major_go_version_update",
-      "commitMessagePrefix": "🚨 Major: ",
-      "commitMessageAction": "Update Go"
+      "matchUpdateTypes": [ "major" ],
+      "groupName": "all major updates",
+      "commitMessagePrefix": "🚨 Major:",
+      "labels": [ "major-update" ]
     },
     {
-      "description": "Group major Go Docker image updates with clear labeling",
-      "matchManagers": [
-        "dockerfile"
-      ],
-      "matchPackageNames": [
-        "golang",
-        "go",
-        "docker.io/library/golang"
-      ],
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "groupName": "major_go_version_update",
-      "commitMessagePrefix": "🚨 Major: ",
-      "commitMessageAction": "Update Go"
+      "matchManagers": [ "dockerfile" ],
+      "groupName": "docker images"
     },
     {
-      "description": "Disable minor version updates for v0 majors (unstable API)",
-      "matchCurrentVersion": "/^0\\./",
-      "matchUpdateTypes": [
-        "minor"
-      ],
-      "enabled": false
+      "matchManagers": [ "gomod" ],
+      "groupName": "go modules"
     },
     {
-      "description": "Enable minor and patch Go version updates with grouping",
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchDepNames": [
-        "go",
-        "toolchain"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "groupName": "go_version_update",
-      "commitMessageAction": "Update Go"
+      "matchManagers": [ "github-actions" ],
+      "groupName": "github actions"
     },
     {
-      "description": "Enable minor and patch Go Docker updates with grouping",
-      "matchManagers": [
-        "dockerfile"
-      ],
-      "matchDepNames": [
-        "docker.io/library/golang",
-        "golang",
-        "go"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "groupName": "go_version_update",
-      "commitMessageAction": "Update Go"
+      "matchPackageNames": [ "go", "toolchain" ],
+      "groupName": "go version"
     },
     {
-      "description": "Group Go module updates (excluding Go version itself)",
-      "matchManagers": [
-        "gomod"
-      ],
-      "excludePackageNames": [
-        "go",
-        "toolchain"
-      ],
-      "groupName": "go_module_updates",
-      "commitMessageAction": "Update Go dependencies"
-    },
-    {
-      "description": "Enable Tekton automerge for safe updates",
-      "matchManagers": [
-        "tekton"
-      ],
-      "matchUpdateTypes": [
-        "patch",
-        "pin",
-        "digest"
-      ],
+      "matchPackageNames": [ "github.com/tektoncd/pipeline" ],
+      "groupName": "tektoncd pipelines",
+      "matchUpdateTypes": [ "minor", "patch", "pin", "digest" ],
       "automerge": true
     },
     {
-      "description": "Group other Docker updates",
-      "matchManagers": [
-        "dockerfile"
-      ],
-      "excludePackageNames": [
-        "docker.io/library/golang",
-        "golang",
-        "go"
-      ],
-      "versioning": "semver",
-      "groupName": "docker_updates",
-      "commitMessageAction": "Update Docker images"
-    },
-    {
-      "description": "Automerge GitHub Actions updates",
-      "matchFiles": [
-        ".github/workflows/*.yml",
-        ".github/workflows/*.yaml"
-      ],
-      "automerge": true,
-      "groupName": "github_actions_updates",
-      "commitMessageAction": "Update GitHub Actions"
+      "matchPackageNames": [ "*" ],
+      "automerge": false,
+      "matchUpdateTypes": [ "major" ],
+      "labels": [ "major-update" ]
     }
-  ],
-  "postUpdateOptions": [
-    "gomodTidy"
   ]
 }


### PR DESCRIPTION
This PR tries to simplify the renovate config by using best practices and builtin Renovate features.

This results in a simpler config file,
that should still obtain the same level of clarity and grouping in the generated PRs.

I don't exclude that further iterations might happen, to further improve or adjust the type of PRs being generated.

Ref: https://issues.redhat.com/browse/EC-1417