### PR TITLE
Iterate org-level Renovate configuration

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -3,8 +3,11 @@
   "extends": [
     ":prHourlyLimit2",
     ":prConcurrentLimit10",
-    ":automergeAllPatch",
-    ":ignoreUnstable"
+    ":automergePatch",
+    ":semanticCommitsDisabled",
+    ":ignoreUnstable",
+    ":docker",
+    ":gomod"
   ],
   "labels": [
     "dependencies"
@@ -15,14 +18,6 @@
       "groupName": "all major updates",
       "commitMessagePrefix": "🚨 Major:",
       "labels": [ "major-update" ]
-    },
-    {
-      "matchManagers": [ "dockerfile" ],
-      "groupName": "docker images"
-    },
-    {
-      "matchManagers": [ "gomod" ],
-      "groupName": "go modules"
     },
     {
       "matchManagers": [ "github-actions" ],


### PR DESCRIPTION
This PR tries to further improve the Renovate config by leveraging Renovate default presets: https://docs.renovatebot.com/presets-default

Ref: https://issues.redhat.com/browse/EC-1417