### PR TITLE
fix(renovate): add gomodTidy to org-level postUpdateOptions

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -18,6 +18,9 @@
   // Branch configuration: process main branch and release branches from v0.6 onwards
   "baseBranchPatterns": [ "main", "/^release-v0\\.(\\d{2,}|[6-9])$/", "/^release-v[1-9]\\d*\\.\\d+$/" ],
 
+  // Run go mod tidy after updating Go modules to prevent stale checksums in go.sum
+  "postUpdateOptions": ["gomodTidy"],
+
   "packageRules": [
     {
       // Global rule: All major updates get special treatment


### PR DESCRIPTION
## Summary

- Adds `gomodTidy` to `postUpdateOptions` in the org-level Renovate config
- Ensures Renovate runs `go mod tidy` after updating Go module dependencies, preventing stale checksums in `go.sum` from breaking CI
- This was proven effective in `go-gather` ([PR #318](https://github.com/conforma/go-gather/pull/318)) — applying it org-wide so all Go-based repos benefit
- `gomodTidy` is a no-op for non-Go repos, so this is safe to set globally

## Test plan

- [x] Verified in `go-gather`: PR #309 (go-git v5.17.2) passed CI after `gomodTidy` was enabled locally
- [ ] After merge, confirm Renovate Go module PRs across other repos (e.g. `cli`, `policy`) produce clean `go.sum` files

Ref: EC-1765

Made with [Cursor](https://cursor.com)