### PR TITLE
Exclude release-v0.6 from Renovate baseBranchPatterns

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -15,8 +15,8 @@
     "{{baseBranch}}" // Add branch name as label
   ],
 
-  // Branch configuration: process main branch and release branches from v0.6 onwards
-  "baseBranchPatterns": [ "main", "/^release-v0\\.(\\d{2,}|[6-9])$/", "/^release-v[1-9]\\d*\\.\\d+$/" ],
+  // Branch configuration: process main branch and release branches from v0.7 onwards
+  "baseBranchPatterns": [ "main", "/^release-v0\\.(\\d{2,}|[7-9])$/", "/^release-v[1-9]\\d*\\.\\d+$/" ],
 
   // Run go mod tidy after updating Go modules to prevent stale checksums in go.sum
   "postUpdateOptions": ["gomodTidy"],


### PR DESCRIPTION
Updates the shared Renovate config to stop matching `release-v0.6`.

Changes the regex character class lower bound from `[6-9]` to `[7-9]` in
`baseBranchPatterns`. This prevents Renovate and Mintmaker from opening
new PRs against the retired branch.

Ref: https://issues.redhat.com/browse/EC-1767