### PR TITLE
Update security policy for CRA

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,10 +1,23 @@
-# Security Policy
-
-## Reporting a Vulnerability
+# Reporting a Security Vulnerability or Incident for Conforma
 
 To report a security issue, please click on the "Report a vulnerability" button from the "Security" tab.
-See detailed [instructions]([url](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability)https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability).
 
-The maintainers will respond within 3 working days of the report.
+To help us triage and resolve the issue efficiently, please follow the instructions for [Privately reporting a security vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability).
+
 If the issue is confirmed as a vulnerability, we will open a Security Advisory.
 We will fully acknowledge the reporter for responsibly disclosing the vulnerability.
+
+## Response Timeline
+
+The maintainers will respond within 3 working days of the report.
+
+## Security Policy
+
+Full details of Red Hat’s security disclosure and remediation process can be found here: <https://access.redhat.com/articles/red-hat-coordinated-vulnerability-disclosure>
+
+## EU Cyber Resilience Act — Open Source Steward Statement
+
+This project is stewarded by **Red Hat, Inc.**, an open source software steward as defined in Article 3(14) of the [EU Cyber Resilience Act (Regulation 2024/2847)](https://eur-lex.europa.eu/eli/reg/2024/2847/oj/eng).
+Contact: [cra-steward@redhat.com](mailto:cra-steward@redhat.com)
+
+Refer to [Red Hat's security practices and vulnerability management policy](https://access.redhat.com/security/) for detailed information.


### PR DESCRIPTION
Updated security policy for EU Cyber Resilience Act (CRA).

GitHub will render this as the default security policy for all repositories under the conforma org.

For: [KONFLUX-15176](https://redhat.atlassian.net/browse/KONFLUX-15176)