### PR TITLE
Add helpers:pinGitHubActionDigests to org-wide Renovate config

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -7,7 +7,8 @@
     ":prConcurrentLimit20", // Allow up to 20 open PRs simultaneously
     ":automergePatch", // Auto-merge patch updates (safe changes)
     ":semanticCommitsDisabled", // Use plain commit messages
-    ":ignoreUnstable" // Skip pre-release versions
+    ":ignoreUnstable", // Skip pre-release versions
+    "helpers:pinGitHubActionDigests" // Pin GitHub Actions to SHA digests for security
   ],
 
   "labels": [


### PR DESCRIPTION
## Summary

- Adds `helpers:pinGitHubActionDigests` preset to the shared org-wide Renovate config
- This ensures all conforma repos get automatic GitHub Action SHA pinning for security
- Previously only configured locally in `conforma/cli` (via EC-2045)

## Context

Stefano suggested promoting this org-wide since it's relevant to all repos (feedback on cli#3463).

A follow-up PR in `conforma/cli` removes the now-redundant local override.

Resolves: [EC-2080](https://redhat.atlassian.net/browse/EC-2080)